### PR TITLE
prevent repayment for centers which has local payment

### DIFF
--- a/src/modules/myTurn/components/turn/footer/footer.tsx
+++ b/src/modules/myTurn/components/turn/footer/footer.tsx
@@ -281,6 +281,7 @@ export const TurnFooter: React.FC<TurnFooterProps> = props => {
     });
   };
 
+  const localPaymentCenters = useFeatureValue<any>('local_payment_centers', []);
   return (
     <>
       {shouldShowMessengerButton && (
@@ -310,7 +311,8 @@ export const TurnFooter: React.FC<TurnFooterProps> = props => {
         )}
       </div>
 
-      {paymentStatus === PaymentStatus.paying && (
+
+      {paymentStatus === PaymentStatus.paying && !(centerId in localPaymentCenters) && (
         <Button variant="primary" block={true} onClick={redirectToFactor}>
           نهایی کردن نوبت
         </Button>


### PR DESCRIPTION
## What does this PR do?

Patients who take appointments from self-hosted centers that have activated local payment, if they do not pay and go to My Appointments, they will see the finalize button, which is designed for offices and deposits, and its rules are different from local centers.

Fixes # (issue)

Don't show the appointment finalization button for this category of patients
