### PR TITLE
Prevent local centers repay

### DIFF
--- a/src/modules/myTurn/components/turn/footer/footer.tsx
+++ b/src/modules/myTurn/components/turn/footer/footer.tsx
@@ -312,7 +312,7 @@ export const TurnFooter: React.FC<TurnFooterProps> = props => {
       </div>
 
 
-      {paymentStatus === PaymentStatus.paying && !(centerId in localPaymentCenters) && (
+      {paymentStatus === PaymentStatus.paying && !localPaymentCenters.includes(centerId) && (
         <Button variant="primary" block={true} onClick={redirectToFactor}>
           نهایی کردن نوبت
         </Button>


### PR DESCRIPTION
## What does this PR do?

Patients who take appointments from self-hosted centers that have activated local payment, if they do not pay and go to My Appointments, they will see the finalize button, which is designed for offices and deposits, and its rules are different from local centers.

Fixes # (issue)

Don't show the appointment finalization button for this category of patients