### PR TITLE
feat: refactor code to simplify logic for showing rate option

### DIFF
--- a/src/common/apis/services/reviews/getReviews.ts
+++ b/src/common/apis/services/reviews/getReviews.ts
@@ -3,22 +3,23 @@ import { useQuery } from '@tanstack/react-query';
 import { ServerStateKeysEnum } from '../../serverStateKeysEnum';
 
 export interface ReviewParams {
-  slug: string;
-  sort: 'default_order' | 'created_at' | 'count_like';
+  slug?: string;
+  sort?: 'default_order' | 'created_at' | 'count_like';
   search?: string;
   user_id?: string;
   not_recommended?: boolean;
   visited?: boolean;
   center_id?: string;
   offset?: number;
-  showOnlyPositiveFeedbacks: boolean;
+  showOnlyPositiveFeedbacks?: boolean;
+  book_id?: string;
 }
 
 export const getReviews = async (params: ReviewParams) => {
   const { data } = await apiGatewayClient.get(`/ravi/v1/feedbacks`, {
     params: {
       where: [
-        `(doctor_slug,eq,${params.slug})`,
+        params.slug && `(doctor_slug,eq,${params.slug})`,
         `(reply_to_feedback_id,is,null)`,
         params.search && `(description,like,${params.search})`,
         params.user_id && `(user_id,eq,${params.user_id})`,
@@ -26,12 +27,13 @@ export const getReviews = async (params: ReviewParams) => {
         params.visited && `(visit_status,eq,visited)`,
         params.center_id && `(center_id,eq,${params.center_id})`,
         params.showOnlyPositiveFeedbacks && `(avg_rate_value,gt,3.5)`,
+        params.book_id && `(book_id,eq,${params.book_id})`,
       ]
         .filter(Boolean)
         .join('~and'),
       limit: 10,
       offset: params?.offset ?? 0,
-      sort: `-${params.sort}`,
+      ...(params.sort && { sort: `-${params.sort}` }),
     },
   });
   return data;

--- a/src/modules/myTurn/components/turn/body/body.tsx
+++ b/src/modules/myTurn/components/turn/body/body.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router';
 import Location from '../../location/location';
 import Rate from '../../rate/rate';
 import TurnDetails from '../../turnDetails';
+import { useGetReview } from '@/common/apis/services/reviews/getReviews';
 
 interface TurnBodyProps {
   detailsData: Array<{ id: number; name: string; value: string | React.ReactNode }>;
@@ -30,10 +31,15 @@ export const TurnBody: React.FC<TurnBodyProps> = props => {
   const { detailsData, status, feedbackUrl, location, centerType, id, centerId, doctorInfo, paymentStatus } = props;
   const router = useRouter();
   const { customize } = useCustomize();
+  const feedback = useGetReview({
+    book_id: id,
+  });
 
   const shouldShowLocation = centerType !== CenterType.consult;
   const shouldShowRate =
-    ((centerId !== CENTERS.CONSULT && status === BookStatus.expired) || (centerId === CENTERS.CONSULT && status === BookStatus.visited)) &&
+    feedback.isSuccess &&
+    feedback?.data?.pageInfo?.totalRows === 0 &&
+    (status === BookStatus.expired || status === BookStatus.visited) &&
     feedbackUrl;
 
   const handleClickCard = () => {


### PR DESCRIPTION
- Modify the ReviewParams interface to make slug, sort, showOnlyPositiveFeedbacks, and book_id optional
- Update the getReviews function to conditionally include parameters in the API request based on their existence
- This change allows for more flexibility when querying feedbacks

Fix issue with displaying rate component in TurnBody

- Import the useGetReview hook from the getReviews module
- Use the useGetReview hook to fetch feedback for a specific book_id
- Update the shouldShowRate condition to check if there are no existing feedbacks for the book
- This ensures that the rate component is only displayed when necessary