### PR TITLE
Add getDoctorFullName API integration to profile data aggregation

### DIFF
--- a/src/common/apis/services/doctor/getDoctorFullName.ts
+++ b/src/common/apis/services/doctor/getDoctorFullName.ts
@@ -1,0 +1,58 @@
+import axios from 'axios';
+import { splunkInstance } from '@/common/services/splunk';
+
+export interface DoctorFullNameResponse {
+  name: string;
+  family: string;
+}
+
+export const getDoctorFullName = async (slug: string): Promise<DoctorFullNameResponse> => {
+  try {
+    const encodedSlug = encodeURIComponent(slug);
+    const url = `https://drprofile.paziresh24.com/api/doctors/${encodedSlug}/fullname`;
+    
+    const { data } = await axios.get<DoctorFullNameResponse>(url, {
+      timeout: 5000,
+      headers: {
+        'Accept': 'application/json',
+      },
+    });
+    
+    // Send success event to Splunk
+    splunkInstance('doctor-profile').sendEvent({
+      group: 'doctor_fullname_api_success',
+      type: 'api_success',
+      event: {
+        slug: slug,
+        url: url,
+        response_data: data,
+        full_name: `${data.name} ${data.family}`,
+        timestamp: new Date().toISOString(),
+      },
+    });
+    
+    return data;
+  } catch (error) {
+    console.error('Error fetching doctor full name:', error);
+    
+    // Send error to Splunk
+    splunkInstance('doctor-profile').sendEvent({
+      group: 'doctor_fullname_api_error',
+      type: 'api_error',
+      event: {
+        slug: slug,
+        url: `https://drprofile.paziresh24.com/api/docts/${encodeURIComponent(slug)}/fullname`,
+        error_message: error instanceof Error ? error.message : String(error),
+        error_status: error instanceof Error && 'response' in error ? (error as any).response?.status : null,
+        error_data: error instanceof Error && 'response' in error ? (error as any).response?.data : null,
+        timestamp: new Date().toISOString(),
+      },
+    });
+    
+    // Return fallback data in case of error
+    return {
+      name: '',
+      family: '',
+    };
+  }
+};

--- a/src/modules/profile/functions/getProfileServerSideProps.ts
+++ b/src/modules/profile/functions/getProfileServerSideProps.ts
@@ -30,6 +30,7 @@ export const getProfileServerSideProps: GetServerSideProps = withCSR(
     try {
       const finalProps = await getAggregatedProfileData(slug, university, true, {
         useClApi: growthbook.isOn('use-clapi-profile-page'),
+        useNewDoctorFullNameAPI: growthbook.isOn('doctor_fullname_for_new_profileapi'),
       });
 
       return {

--- a/src/modules/profile/hooks/useProfileClientFetch.ts
+++ b/src/modules/profile/hooks/useProfileClientFetch.ts
@@ -6,12 +6,14 @@ import { useFeatureIsOn } from '@growthbook/growthbook-react';
 export const useProfileClientFetch = (slug: string, enabled: boolean) => {
   const university = useCustomize(state => state.customize?.partnerKey);
   const isClapiActive = useFeatureIsOn('use-clapi-profile-page');
+  const useNewDoctorFullNameAPI = useFeatureIsOn('doctor_fullname_for_new_profileapi');
 
   return useQuery(
     ['profileClientData', slug],
     () =>
       getAggregatedProfileData(slug, university, false, {
         useClApi: isClapiActive,
+        useNewDoctorFullNameAPI: useNewDoctorFullNameAPI,
       }),
     {
       enabled: enabled,


### PR DESCRIPTION
- Introduced a new API service to fetch the full name of a doctor based on a slug.
- Updated getAggregatedProfileData to conditionally call the new API.
- Modified getProfileServerSideProps and useProfileClientFetch to support the new API option.
- Ensured fallback handling for doctor name in profile data assembly.