### PR TITLE
feat: add google calendar integration to receipt module

### DIFF
--- a/src/common/apis/serverStateKeysEnum.ts
+++ b/src/common/apis/serverStateKeysEnum.ts
@@ -28,4 +28,5 @@ export enum ServerStateKeysEnum {
   OnlineChannels = 'onlineChannels',
   GetCancellationPolicyStatus = 'getCancellationPolicyStatus',
   PaymentMethods = 'paymentMethods',
+  GhandonPreference = 'ghandonPreference',
 }

--- a/src/common/apis/services/ghandon/preference.ts
+++ b/src/common/apis/services/ghandon/preference.ts
@@ -1,0 +1,73 @@
+import { apiGatewayClient } from '@/common/apis/client';
+import { ServerStateKeysEnum } from '@/common/apis/serverStateKeysEnum';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+const GHANDON_PREFERENCE_API_PATH = '/ghandon/preference';
+
+export interface GhandonPreference {
+  email: string;
+  auto_sync: boolean;
+}
+
+export const getGhandonPreference = async (): Promise<GhandonPreference | null> => {
+  try {
+    const { data } = await apiGatewayClient.get<GhandonPreference>(GHANDON_PREFERENCE_API_PATH);
+    const email = data?.email?.trim() ?? '';
+
+    if (!isValidGhandonEmail(email)) {
+      return null;
+    }
+
+    return {
+      email,
+      auto_sync: Boolean(data?.auto_sync),
+    };
+  } catch {
+    return null;
+  }
+};
+
+const isValidGhandonEmail = (email: string) =>
+  email.length > 0 && email.length <= 254 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+export const saveGhandonPreference = async (params: GhandonPreference) => {
+  const email = params.email.trim();
+
+  if (!isValidGhandonEmail(email)) {
+    throw new Error('Invalid email');
+  }
+
+  const { data } = await apiGatewayClient.put<GhandonPreference>(GHANDON_PREFERENCE_API_PATH, {
+    email,
+    auto_sync: Boolean(params.auto_sync),
+  });
+  return data;
+};
+
+export const useGhandonPreference = (enabled = true) => {
+  return useQuery([ServerStateKeysEnum.GhandonPreference], getGhandonPreference, {
+    enabled,
+    staleTime: 60_000,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+};
+
+export const useSaveGhandonPreference = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation(saveGhandonPreference, {
+    onSuccess: data => {
+      const email = data?.email?.trim() ?? '';
+
+      if (!isValidGhandonEmail(email)) {
+        return;
+      }
+
+      queryClient.setQueryData<GhandonPreference | null>([ServerStateKeysEnum.GhandonPreference], {
+        email,
+        auto_sync: Boolean(data?.auto_sync),
+      });
+    },
+  });
+};

--- a/src/common/components/icons/googleCalendar.tsx
+++ b/src/common/components/icons/googleCalendar.tsx
@@ -1,7 +1,7 @@
 import { memo, SVGAttributes } from 'react';
 
-export const GoogleCalendarIcon = memo(({ ...rest }: SVGAttributes<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" {...rest}>
+export const GoogleCalendarIcon = memo(({ className, width, height, ...rest }: SVGAttributes<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" {...rest} className={className} width={width ?? 26} height={height ?? 26}>
     <rect width="22" height="22" x="13" y="13" fill="#fff" />
     <polygon fill="#1e88e5" points="25.68,20.92 26.688,22.36 28.272,21.208 28.272,29.56 30,29.56 30,18.616 28.56,18.616" />
     <path

--- a/src/modules/receipt/components/GoogleCalendarAddEvent/GoogleCalendarAddEvent.tsx
+++ b/src/modules/receipt/components/GoogleCalendarAddEvent/GoogleCalendarAddEvent.tsx
@@ -1,5 +1,6 @@
-import GoogleCalendarIcon from '@/common/components/icons/googleCalendar';
+import { useGhandonPreference, useSaveGhandonPreference } from '@/common/apis/services/ghandon/preference';
 import { apiGatewayClient } from '@/common/apis/client';
+import GoogleCalendarIcon from '@/common/components/icons/googleCalendar';
 import useModal from '@/common/hooks/useModal';
 import classNames from '@/common/utils/classNames';
 import { useUserInfoStore } from '@/modules/login/store/userInfo';
@@ -8,7 +9,7 @@ import { toast } from 'react-hot-toast';
 import { ADD_EVENT_API_PATH } from './constants';
 import { GoogleCalendarEmailModal } from './GoogleCalendarEmailModal';
 import styles from './googleCalendarAddEvent.module.css';
-import { getLastUsedEmail, isValidEmail, saveLastUsedEmail } from './utils';
+import { getLastUsedEmail, getSubmittedEmail, isValidEmail, saveLastUsedEmail, saveSubmittedEmail } from './utils';
 
 type IconStatus = 'idle' | 'loading' | 'success';
 
@@ -18,25 +19,50 @@ export interface GoogleCalendarAddEventProps {
 }
 
 export const GoogleCalendarAddEvent = ({ bookId, centerId }: GoogleCalendarAddEventProps) => {
+  const normalizedBookId = bookId?.trim() ?? '';
+  const normalizedCenterId = centerId?.trim() ?? '';
+
   const userEmail = useUserInfoStore(state => state.info?.email);
+  const isLogin = useUserInfoStore(state => state.isLogin);
   const { handleOpen, handleClose, modalProps } = useModal();
   const inputRef = useRef<HTMLInputElement>(null);
   const isActiveRef = useRef(true);
-  const iconStatusRef = useRef<IconStatus>('idle');
+  const isSubmittingRef = useRef(false);
+  const autoSyncAttemptedRef = useRef(false);
+  const [isSaving, setIsSaving] = useState(false);
 
-  const [iconStatus, setIconStatus] = useState<IconStatus>('idle');
-  const [email, setEmail] = useState('');
+  const { data: preference } = useGhandonPreference(isLogin);
+  const savePreference = useSaveGhandonPreference();
 
-  iconStatusRef.current = iconStatus;
+  const autoSyncEnabled = Boolean(preference?.auto_sync && preference.email);
+  const preferenceEmail = preference?.email?.trim() ?? '';
 
-  const handleModalClose = useCallback(() => {
-    if (iconStatusRef.current === 'loading') {
-      return;
+  const [iconStatus, setIconStatus] = useState<IconStatus>(() => {
+    if (getSubmittedEmail(normalizedCenterId, normalizedBookId)) {
+      return 'success';
     }
 
-    saveLastUsedEmail(inputRef.current?.value ?? '');
+    return 'idle';
+  });
+  const [email, setEmail] = useState('');
+  const [isEditing, setIsEditing] = useState(false);
+  const [autoSync, setAutoSync] = useState(false);
+  const [initialAutoSync, setInitialAutoSync] = useState(false);
+  const [submittedEmail, setSubmittedEmail] = useState(() => getSubmittedEmail(normalizedCenterId, normalizedBookId));
+
+  const handleModalClose = useCallback(() => {
+    const savedSubmittedEmail = getSubmittedEmail(normalizedCenterId, normalizedBookId);
+
+    if (savedSubmittedEmail || autoSyncEnabled) {
+      setEmail(savedSubmittedEmail || preferenceEmail);
+      setSubmittedEmail(savedSubmittedEmail);
+      setIsEditing(false);
+      setAutoSync(autoSyncEnabled);
+      setInitialAutoSync(autoSyncEnabled);
+    }
+
     handleClose();
-  }, [handleClose]);
+  }, [autoSyncEnabled, handleClose, normalizedBookId, normalizedCenterId, preferenceEmail]);
 
   useEffect(() => {
     isActiveRef.current = true;
@@ -47,11 +73,36 @@ export const GoogleCalendarAddEvent = ({ bookId, centerId }: GoogleCalendarAddEv
   }, []);
 
   useEffect(() => {
+    autoSyncAttemptedRef.current = false;
+    const savedSubmittedEmail = getSubmittedEmail(normalizedCenterId, normalizedBookId);
+
+    setSubmittedEmail(savedSubmittedEmail);
+    setIconStatus(savedSubmittedEmail ? 'success' : 'idle');
+    setIsEditing(false);
+    setAutoSync(false);
+    setInitialAutoSync(false);
+  }, [normalizedBookId, normalizedCenterId]);
+
+  useEffect(() => {
+    if (!autoSyncEnabled || !preferenceEmail) {
+      return;
+    }
+
+    setAutoSync(true);
+    setInitialAutoSync(true);
+
+    if (getSubmittedEmail(normalizedCenterId, normalizedBookId)) {
+      setIconStatus(prev => (prev === 'loading' ? prev : 'success'));
+    }
+  }, [autoSyncEnabled, normalizedBookId, normalizedCenterId, preferenceEmail]);
+
+  useEffect(() => {
     if (!modalProps.isOpen) {
       return;
     }
 
-    const focusTimer = window.setTimeout(() => inputRef.current?.focus(), 80);
+    const shouldFocus = !submittedEmail || isEditing;
+    const focusTimer = shouldFocus ? window.setTimeout(() => inputRef.current?.focus(), 80) : undefined;
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         handleModalClose();
@@ -61,20 +112,26 @@ export const GoogleCalendarAddEvent = ({ bookId, centerId }: GoogleCalendarAddEv
     document.addEventListener('keydown', handleEscape);
 
     return () => {
-      window.clearTimeout(focusTimer);
+      if (focusTimer) {
+        window.clearTimeout(focusTimer);
+      }
       document.removeEventListener('keydown', handleEscape);
     };
-  }, [handleModalClose, modalProps.isOpen]);
+  }, [handleModalClose, isEditing, modalProps.isOpen, submittedEmail]);
 
   const sendToCalendar = useCallback(
-    async (targetEmail: string) => {
+    async (targetEmail: string, options?: { silent?: boolean }) => {
+      if (!normalizedBookId || !normalizedCenterId || !isValidEmail(targetEmail)) {
+        return;
+      }
+
       setIconStatus('loading');
 
       try {
         await apiGatewayClient.post(ADD_EVENT_API_PATH, {
-          email: targetEmail,
-          book_id: bookId,
-          center_id: centerId,
+          email: targetEmail.trim(),
+          book_id: normalizedBookId,
+          center_id: normalizedCenterId,
         });
 
         if (!isActiveRef.current) {
@@ -82,20 +139,46 @@ export const GoogleCalendarAddEvent = ({ bookId, centerId }: GoogleCalendarAddEv
         }
 
         saveLastUsedEmail(targetEmail);
+        saveSubmittedEmail(normalizedCenterId, normalizedBookId, targetEmail);
+        setSubmittedEmail(targetEmail.trim());
+        setIsEditing(false);
         setIconStatus('success');
-        handleClose();
-        toast.success('نوبت به Google Calendar اضافه شد');
+
+        if (!options?.silent) {
+          toast.success('نوبت به Google Calendar اضافه شد');
+        }
       } catch {
         if (!isActiveRef.current) {
           return;
         }
 
-        setIconStatus('idle');
-        toast.error('افزودن به تقویم انجام نشد. لطفا دوباره تلاش کنید');
+        if (options?.silent) {
+          autoSyncAttemptedRef.current = false;
+        }
+
+        const wasSubmitted = Boolean(getSubmittedEmail(normalizedCenterId, normalizedBookId));
+        setIconStatus(wasSubmitted ? 'success' : 'idle');
+
+        if (!options?.silent) {
+          toast.error('افزودن به تقویم انجام نشد. لطفا دوباره تلاش کنید');
+        }
       }
     },
-    [bookId, centerId, handleClose],
+    [normalizedBookId, normalizedCenterId],
   );
+
+  useEffect(() => {
+    if (!autoSyncEnabled || !preferenceEmail || autoSyncAttemptedRef.current) {
+      return;
+    }
+
+    if (getSubmittedEmail(normalizedCenterId, normalizedBookId)) {
+      return;
+    }
+
+    autoSyncAttemptedRef.current = true;
+    sendToCalendar(preferenceEmail, { silent: true });
+  }, [autoSyncEnabled, normalizedBookId, normalizedCenterId, preferenceEmail, sendToCalendar]);
 
   const handleIconClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -105,12 +188,35 @@ export const GoogleCalendarAddEvent = ({ bookId, centerId }: GoogleCalendarAddEv
       return;
     }
 
-    setEmail(getLastUsedEmail(userEmail));
+    const savedSubmittedEmail = getSubmittedEmail(normalizedCenterId, normalizedBookId);
+    setSubmittedEmail(savedSubmittedEmail);
+
+    if (savedSubmittedEmail) {
+      setEmail(savedSubmittedEmail);
+      setIsEditing(false);
+      setAutoSync(autoSyncEnabled);
+      setInitialAutoSync(autoSyncEnabled);
+    } else if (autoSyncEnabled && preferenceEmail) {
+      setEmail(preferenceEmail);
+      setIsEditing(false);
+      setAutoSync(true);
+      setInitialAutoSync(true);
+    } else {
+      setEmail(getLastUsedEmail(userEmail));
+      setIsEditing(true);
+      setAutoSync(false);
+      setInitialAutoSync(false);
+    }
+
     handleOpen();
   };
 
-  const handleSubmit = (event: FormEvent) => {
+  const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
+
+    if (isSubmittingRef.current) {
+      return;
+    }
 
     const trimmedEmail = email.trim();
     if (!isValidEmail(trimmedEmail)) {
@@ -118,8 +224,61 @@ export const GoogleCalendarAddEvent = ({ bookId, centerId }: GoogleCalendarAddEv
       return;
     }
 
-    sendToCalendar(trimmedEmail);
+    const savedBookEmail = getSubmittedEmail(normalizedCenterId, normalizedBookId);
+    const isLocked = Boolean(submittedEmail) && !isEditing;
+    const hasPreferenceChanges = autoSync !== initialAutoSync;
+    const shouldSavePreference =
+      isLogin && (hasPreferenceChanges || (autoSync && trimmedEmail !== preferenceEmail));
+    const shouldAddEvent = !isLocked && (!savedBookEmail || trimmedEmail !== savedBookEmail);
+
+    isSubmittingRef.current = true;
+    setIsSaving(true);
+    saveLastUsedEmail(trimmedEmail);
+
+    try {
+      if (shouldSavePreference) {
+        try {
+          await savePreference.mutateAsync({
+            email: trimmedEmail,
+            auto_sync: autoSync,
+          });
+          setInitialAutoSync(autoSync);
+
+          if (autoSync && !initialAutoSync) {
+            toast.success('از این پس نوبت‌ها به‌صورت خودکار به تقویم اضافه می‌شوند');
+          } else if (!autoSync && initialAutoSync) {
+            toast.success('افزودن خودکار به تقویم غیرفعال شد');
+          }
+        } catch {
+          toast.error('ذخیره تنظیمات انجام نشد. لطفا دوباره تلاش کنید');
+          return;
+        }
+      }
+
+      handleClose();
+
+      if (shouldAddEvent) {
+        await sendToCalendar(trimmedEmail);
+      }
+    } finally {
+      isSubmittingRef.current = false;
+      setIsSaving(false);
+    }
   };
+
+  const handleEdit = useCallback(() => {
+    setIsEditing(true);
+    window.setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }, 80);
+  }, []);
+
+  if (!normalizedBookId || !normalizedCenterId) {
+    return null;
+  }
+
+  const isLocked = Boolean(submittedEmail) && !isEditing;
 
   const iconClassName = classNames(styles.icon, {
     [styles.iconLoading]: iconStatus === 'loading',
@@ -127,9 +286,13 @@ export const GoogleCalendarAddEvent = ({ bookId, centerId }: GoogleCalendarAddEv
   });
 
   const triggerTitle =
-    iconStatus === 'success'
-      ? 'نوبت به Google Calendar اضافه شده'
-      : 'برای افزودن نوبت به Google Calendar کلیک کنید';
+    iconStatus === 'loading'
+      ? 'در حال ارسال دعوتنامه...'
+      : autoSyncEnabled && iconStatus === 'success'
+        ? 'نوبت‌ها به‌صورت خودکار به Google Calendar اضافه می‌شوند'
+        : iconStatus === 'success'
+          ? 'نوبت به Google Calendar اضافه شده'
+          : 'برای افزودن نوبت به Google Calendar کلیک کنید';
 
   return (
     <>
@@ -140,20 +303,28 @@ export const GoogleCalendarAddEvent = ({ bookId, centerId }: GoogleCalendarAddEv
           title={triggerTitle}
           aria-busy={iconStatus === 'loading'}
           aria-expanded={modalProps.isOpen}
-          className={styles.trigger}
+          className={classNames(styles.trigger, {
+            [styles.triggerLoading]: iconStatus === 'loading',
+          })}
           onClick={handleIconClick}
           disabled={iconStatus === 'loading'}
         >
-          <GoogleCalendarIcon className={iconClassName} aria-hidden />
+          <GoogleCalendarIcon className={iconClassName} width={26} height={26} aria-hidden />
         </button>
       </div>
 
       <GoogleCalendarEmailModal
         isOpen={modalProps.isOpen}
-        isLoading={iconStatus === 'loading'}
+        isSaving={isSaving}
         email={email}
+        isLocked={isLocked}
+        autoSync={autoSync}
+        initialAutoSync={initialAutoSync}
+        showAutoSyncOption={isLogin}
         inputRef={inputRef}
         onClose={handleModalClose}
+        onEdit={handleEdit}
+        onAutoSyncChange={setAutoSync}
         onEmailChange={setEmail}
         onSubmit={handleSubmit}
       />

--- a/src/modules/receipt/components/GoogleCalendarAddEvent/GoogleCalendarAddEventButton.tsx
+++ b/src/modules/receipt/components/GoogleCalendarAddEvent/GoogleCalendarAddEventButton.tsx
@@ -1,19 +1,13 @@
-import dynamic from 'next/dynamic';
 import { useFeatureIsOn } from '@growthbook/growthbook-react';
-import { GoogleCalendarAddEventProps } from './GoogleCalendarAddEvent';
+import { GoogleCalendarAddEvent, GoogleCalendarAddEventProps } from './GoogleCalendarAddEvent';
 import { GOOGLE_CALENDAR_ADD_EVENT_ENABLED_KEY } from './constants';
-
-const GoogleCalendarAddEventLazy = dynamic<GoogleCalendarAddEventProps>(
-  () => import('./GoogleCalendarAddEvent').then(module => module.GoogleCalendarAddEvent),
-  { ssr: false },
-);
 
 export const GoogleCalendarAddEventButton = (props: GoogleCalendarAddEventProps) => {
   const isEnabled = useFeatureIsOn(GOOGLE_CALENDAR_ADD_EVENT_ENABLED_KEY);
 
-  if (!isEnabled) {
+  if (!isEnabled || !props.bookId?.trim() || !props.centerId?.trim()) {
     return null;
   }
 
-  return <GoogleCalendarAddEventLazy {...props} />;
+  return <GoogleCalendarAddEvent {...props} />;
 };

--- a/src/modules/receipt/components/GoogleCalendarAddEvent/GoogleCalendarEmailModal.tsx
+++ b/src/modules/receipt/components/GoogleCalendarAddEvent/GoogleCalendarEmailModal.tsx
@@ -1,55 +1,131 @@
 import Button from '@/common/components/atom/button';
 import Modal from '@/common/components/atom/modal';
+import Switch from '@/common/components/atom/switch';
+import Text from '@/common/components/atom/text';
 import TextField from '@/common/components/atom/textField';
+import EditIcon from '@/common/components/icons/edit';
 import classNames from '@/common/utils/classNames';
 import { FormEvent, RefObject } from 'react';
+import styles from './googleCalendarAddEvent.module.css';
 import { isValidEmail } from './utils';
 
 interface GoogleCalendarEmailModalProps {
   isOpen: boolean;
-  isLoading: boolean;
+  isSaving?: boolean;
   email: string;
+  isLocked: boolean;
+  autoSync: boolean;
+  initialAutoSync: boolean;
+  showAutoSyncOption: boolean;
   inputRef: RefObject<HTMLInputElement>;
   onClose: () => void;
+  onEdit: () => void;
+  onAutoSyncChange: (value: boolean) => void;
   onEmailChange: (value: string) => void;
   onSubmit: (event: FormEvent) => void;
 }
 
 export const GoogleCalendarEmailModal = ({
   isOpen,
-  isLoading,
+  isSaving = false,
   email,
+  isLocked,
+  autoSync,
+  initialAutoSync,
+  showAutoSyncOption,
   inputRef,
   onClose,
+  onEdit,
+  onAutoSyncChange,
   onEmailChange,
   onSubmit,
 }: GoogleCalendarEmailModalProps) => {
   const trimmedEmail = email.trim();
   const isEmailValid = isValidEmail(trimmedEmail);
-  const showInvalidEmail = trimmedEmail.length > 0 && !isEmailValid;
+  const showInvalidEmail = !isLocked && trimmedEmail.length > 0 && !isEmailValid;
+  const hasPreferenceChanges = autoSync !== initialAutoSync;
+  const isSubmitDisabled = isLocked ? !hasPreferenceChanges || isSaving : !isEmailValid || isSaving;
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="اضافه کردن نوبت به تقویم گوگل" >
-      <form onSubmit={onSubmit} className="flex flex-col gap-4">
-        <TextField
-          ref={inputRef}
-          label="ایمیل خود را وارد کنید:"
-          type="email"
-          dir="ltr"
-          inputMode="email"
-          autoComplete="email"
-          placeholder="example@email.com"
-          value={email}
-          onChange={event => onEmailChange(event.target.value)}
-          disabled={isLoading}
-          error={showInvalidEmail}
-          helperText={showInvalidEmail ? 'ایمیل وارد شده معتبر نیست' : undefined}
-          className={classNames({
-            '!border-green-400 !bg-green-50': isEmailValid,
-          })}
-        />
-        <Button type="submit" block loading={isLoading} disabled={!isEmailValid || isLoading}>
-          ثبت
+    <Modal isOpen={isOpen} onClose={onClose} title="اضافه کردن نوبت به تقویم گوگل">
+      <form onSubmit={onSubmit} className={styles.modalForm}>
+        {isLocked ? (
+          <div className="flex flex-col space-y-2">
+            <Text fontSize="sm" fontWeight="medium" className="text-black">
+              ایمیل خود را وارد کنید:
+            </Text>
+            <div className={styles.modalLockedEmailBox}>
+              <span className={styles.modalEmailSuccessPulse} aria-label="ارسال موفق" role="status" />
+              <Text dir="ltr" fontSize="sm" className="min-w-0 flex-1 truncate text-left text-slate-700">
+                {email}
+              </Text>
+              <button type="button" aria-label="ویرایش ایمیل" title="ویرایش ایمیل" className={styles.modalEditButton} onClick={onEdit}>
+                <EditIcon className="h-5 w-5" />
+              </button>
+            </div>
+          </div>
+        ) : (
+          <TextField
+            ref={inputRef}
+            label="ایمیل خود را وارد کنید:"
+            type="email"
+            dir="ltr"
+            inputMode="email"
+            autoComplete="email"
+            placeholder="example@email.com"
+            value={email}
+            onChange={event => onEmailChange(event.target.value)}
+            error={showInvalidEmail}
+            helperText={showInvalidEmail ? 'ایمیل وارد شده معتبر نیست' : undefined}
+            className={classNames({
+              '!border-green-400 !bg-green-50': isEmailValid,
+            })}
+          />
+        )}
+
+        {showAutoSyncOption && (
+          <div
+            className={classNames(styles.modalAutoSyncCard, {
+              [styles.modalAutoSyncCardActive]: autoSync,
+            })}
+          >
+            <div className={styles.modalAutoSyncRow}>
+              <button type="button" className={styles.modalAutoSyncLabel} onClick={() => onAutoSyncChange(!autoSync)}>
+                <Text fontSize="sm" fontWeight="medium" className="text-slate-800">
+                  افزودن خودکار به تقویم
+                </Text>
+                {autoSync && (
+                  <span className={styles.modalStatusBadge}>
+                    <span className={styles.modalStatusPulse} aria-hidden />
+                    فعال
+                  </span>
+                )}
+              </button>
+              <Switch
+                checked={autoSync}
+                onChange={event => {
+                  event.stopPropagation();
+                  onAutoSyncChange(event.target.checked);
+                }}
+              />
+            </div>
+            <div
+              className={classNames(styles.modalAutoSyncHint, {
+                [styles.modalAutoSyncHintOpen]: autoSync,
+              })}
+              aria-hidden={!autoSync}
+            >
+              <div className={styles.modalAutoSyncHintInner}>
+                <p className={styles.modalAutoSyncHintText}>
+                  نوبت‌های شما به صورت خودکار، به تقویم گوگل شما اضافه خواهند شد.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <Button type="submit" block loading={isSaving} disabled={isSubmitDisabled}>
+          {isLocked && hasPreferenceChanges ? 'ذخیره تنظیمات' : 'ثبت'}
         </Button>
       </form>
     </Modal>

--- a/src/modules/receipt/components/GoogleCalendarAddEvent/constants.ts
+++ b/src/modules/receipt/components/GoogleCalendarAddEvent/constants.ts
@@ -1,4 +1,5 @@
 export const ADD_EVENT_API_PATH = '/ghandon/add-event';
 export const EMAIL_STORAGE_KEY = 'p24_gcal_email';
+export const SUBMITTED_EVENTS_STORAGE_KEY = 'p24_gcal_submitted_events';
 
 export const GOOGLE_CALENDAR_ADD_EVENT_ENABLED_KEY = 'receipt:ghandon';

--- a/src/modules/receipt/components/GoogleCalendarAddEvent/googleCalendarAddEvent.module.css
+++ b/src/modules/receipt/components/GoogleCalendarAddEvent/googleCalendarAddEvent.module.css
@@ -1,3 +1,9 @@
+@keyframes gcal-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @keyframes gcal-loading-pulse {
   0%,
   100% {
@@ -53,7 +59,7 @@
 }
 
 .trigger:focus-visible {
-  outline: 2px solid #60a5fa;
+  outline: 2px solid #3861fb;
   outline-offset: 2px;
 }
 
@@ -61,9 +67,22 @@
   cursor: wait;
 }
 
+.triggerLoading::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: 9999px;
+  border: 2px solid rgb(56 97 251 / 0.15);
+  border-top-color: #3861fb;
+  animation: gcal-spin 0.9s linear infinite;
+  pointer-events: none;
+}
+
 .icon {
   position: relative;
   z-index: 1;
+  display: block;
+  flex-shrink: 0;
   width: 1.65rem;
   height: 1.65rem;
   transform-origin: center;
@@ -81,7 +100,225 @@
 
 @media (prefers-reduced-motion: reduce) {
   .iconLoading,
-  .iconSuccess {
+  .iconSuccess,
+  .triggerLoading::before {
     animation: none;
+  }
+}
+
+.modalForm {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modalLockedEmailBox {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-height: 3rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #4ade80;
+  border-radius: 0.5rem;
+  background: #f0fdf4;
+}
+
+.modalEditButton {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  border-radius: 0.375rem;
+  color: #64748b;
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.modalEditButton:hover {
+  color: #3861fb;
+  background: rgb(56 97 251 / 0.05);
+}
+
+.modalEmailSuccessPulse {
+  position: relative;
+  flex-shrink: 0;
+  width: 0.5rem;
+  height: 0.5rem;
+}
+
+.modalEmailSuccessPulse::before,
+.modalEmailSuccessPulse::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+  background: #16a34a;
+}
+
+.modalEmailSuccessPulse::before {
+  animation: gcal-status-pulse 1.8s ease-in-out infinite;
+}
+
+.modalEmailSuccessPulse::after {
+  opacity: 0.45;
+  animation: gcal-status-wave 1.8s ease-out infinite;
+}
+
+.modalAutoSyncCard {
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  background: #fff;
+  transition: border-color 0.25s ease, background-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.modalAutoSyncCardActive {
+  border-color: rgb(56 97 251 / 0.28);
+  background: rgb(56 97 251 / 0.03);
+  box-shadow: 0 0 0 1px rgb(56 97 251 / 0.06);
+}
+
+.modalAutoSyncRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
+  min-height: 2.75rem;
+}
+
+.modalAutoSyncLabel {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  flex: 1;
+  cursor: pointer;
+  text-align: start;
+}
+
+.modalStatusBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex-shrink: 0;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1.125rem;
+  color: #3861fb;
+  background: rgb(56 97 251 / 0.12);
+  animation: gcal-badge-in 0.25s ease-out;
+}
+
+.modalStatusPulse {
+  position: relative;
+  flex-shrink: 0;
+  width: 0.5rem;
+  height: 0.5rem;
+}
+
+.modalStatusPulse::before,
+.modalStatusPulse::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+  background: #3861fb;
+}
+
+.modalStatusPulse::before {
+  animation: gcal-status-pulse 1.8s ease-in-out infinite;
+}
+
+.modalStatusPulse::after {
+  opacity: 0.45;
+  animation: gcal-status-wave 1.8s ease-out infinite;
+}
+
+@keyframes gcal-status-pulse {
+  0%,
+  100% {
+    transform: scale(0.82);
+    opacity: 0.75;
+  }
+  50% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes gcal-status-wave {
+  0% {
+    transform: scale(0.85);
+    opacity: 0.55;
+  }
+  70%,
+  100% {
+    transform: scale(2.2);
+    opacity: 0;
+  }
+}
+
+.modalAutoSyncHint {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.28s ease;
+}
+
+.modalAutoSyncHintOpen {
+  grid-template-rows: 1fr;
+}
+
+.modalAutoSyncHintInner {
+  overflow: hidden;
+}
+
+.modalAutoSyncHintText {
+  padding: 0 0.75rem 0.625rem;
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+  color: #64748b;
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity 0.28s ease, transform 0.28s ease;
+}
+
+.modalAutoSyncHintOpen .modalAutoSyncHintText {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@keyframes gcal-badge-in {
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modalAutoSyncHint,
+  .modalAutoSyncHintText,
+  .modalStatusBadge,
+  .modalStatusPulse::before,
+  .modalStatusPulse::after,
+  .modalEmailSuccessPulse::before,
+  .modalEmailSuccessPulse::after {
+    animation: none;
+    transition: none;
+  }
+
+  .modalAutoSyncHintOpen {
+    grid-template-rows: 1fr;
+  }
+
+  .modalAutoSyncHintOpen .modalAutoSyncHintText {
+    opacity: 1;
+    transform: none;
   }
 }

--- a/src/modules/receipt/components/GoogleCalendarAddEvent/utils.ts
+++ b/src/modules/receipt/components/GoogleCalendarAddEvent/utils.ts
@@ -1,6 +1,57 @@
-import { EMAIL_STORAGE_KEY } from './constants';
+import { EMAIL_STORAGE_KEY, SUBMITTED_EVENTS_STORAGE_KEY } from './constants';
 
-export const isValidEmail = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+const MAX_EMAIL_LENGTH = 254;
+
+export const isValidEmail = (email: string) =>
+  email.length > 0 && email.length <= MAX_EMAIL_LENGTH && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+const getEventStorageKey = (centerId: string, bookId: string) => `${centerId}:${bookId}`;
+
+const readSubmittedEvents = (): Record<string, string> => {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+
+  try {
+    const raw = window.localStorage.getItem(SUBMITTED_EVENTS_STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>).filter(
+        ([key, value]) => typeof key === 'string' && typeof value === 'string',
+      ),
+    ) as Record<string, string>;
+  } catch {
+    return {};
+  }
+};
+
+export const getSubmittedEmail = (centerId: string, bookId: string) => {
+  const storedEmail = readSubmittedEvents()[getEventStorageKey(centerId, bookId)]?.trim() ?? '';
+  return isValidEmail(storedEmail) ? storedEmail : '';
+};
+
+export const saveSubmittedEmail = (centerId: string, bookId: string, email: string) => {
+  const trimmedEmail = email.trim();
+  if (!isValidEmail(trimmedEmail) || typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    const submittedEvents = readSubmittedEvents();
+    submittedEvents[getEventStorageKey(centerId, bookId)] = trimmedEmail;
+    window.localStorage.setItem(SUBMITTED_EVENTS_STORAGE_KEY, JSON.stringify(submittedEvents));
+  } catch {
+    // Ignore quota / private-mode errors; submitted state is a convenience only.
+  }
+};
 
 export const getLastUsedEmail = (profileEmail?: string) => {
   if (typeof window === 'undefined') {


### PR DESCRIPTION
یک فیچری اضافه کردم که وقتی کاربر فعالش میکنه ایمیل کاربر در یک دیتابیسی ذخیره میشه و موقعی که دوباره نوبت میگیره به صورت خودکار بدون اینکه این پاپ اپ را باز کنه و ایمیلش را از اول وارد کنه بتونه. نوبتش به ایمیلی که ذخیره داشته فرستاده بشه.

گزینه اعمال تغییرات را قرار دادم تا زمانی که کاربر نوبتش را وارد کرد و گزینه ثبت را زد این ایمیل به صورت پیشرفت در باکس قفل میشه و گزینه ثبت غیر فعال میشه تا دوباره کلیک نکنه و این ایمیل برای نوبت های بعدی ثبت میشود و اگر خواست که ایمیل خودش را تغییر دهد میتواند با اعمال تغییرات. ایمیل جدید وارد کند.
<
<img width="592" height="365" alt="Screenshot 2026-06-21 132936" src="https://github.com/user-attachments/assets/ba987fa9-1d8b-412e-b7d7-1d8829f29c90" />
<img width="607" height="491" alt="Screenshot 2026-06-21 132943" src="https://github.com/user-attachments/assets/4a106a0e-6c77-4b80-b35e-98bba0ba84eb" />
<img width="641" height="426" alt="Screenshot 2026-06-21 132947" src="https://github.com/user-attachments/assets/4c2e2285-106b-4bf8-8c33-c51f6380d918" />
<img width="547" height="373" alt="Screenshot 2026-06-21 133001" src="https://github.com/user-attachments/assets/4e1cc610-8106-4eb0-a245-19306c964a66" />
